### PR TITLE
[ci] Avoid schedule event upload too many files to codecov

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -97,6 +97,11 @@ jobs:
         run: |
           python -m tox -vv -e code-test
       - uses: codecov/codecov-action@v3
+        # Codecov have a 100-upload limit per commit, and there are 3 * 6 files upload each time run pytest,
+        # We should not run upload in schedule GitHub event, because the sixth day we do not change our code
+        # and the upload limit will be reached 3 * 6 * 6. For more detail can see:
+        # https://community.codecov.com/t/ci-failure-due-to-too-many-uploads-to-this-commit/2587/7
+        if: ${{ github.event_name != 'schedule' }}
         with:
           token: ${{ env.CODECOV_TOKEN }}
           files: ./coverage.xml


### PR DESCRIPTION
codecov have 100 limit in each commit, and then if will failed the upload process, so we should not upload during schedule, because 6 day not change code base will reach the limit. see more detail in https://community.codecov.com/t/ci-failure-due-to-too-many-uploads-to-this-commit/2587/7

<!--Thanks for you contribute to Apache DolphinScheduler Python API, You can see more detail about contributing in https://github.com/apache/dolphinscheduler-sdk-python/DEVELOP.md .-->

## Brief Summary of The Change

<!--Please include `fixes: #XXXX(ISSUE_NUMBER)` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `related: #XXXX(ISSUE_NUMBER)`.-->

## Pull Request checklist

I confirm that the following checklist has been completed.

- [x] Add/Change **test cases** for the changes.
- [x] Add/Change the related **documentation**, should also change `docs/source/config.rst` when you change file `default_config.yaml`.
- [x] (Optional) Add your change to `UPDATING.md` when it is an incompatible change.
