### PR TITLE
[chore] CI python version form 3.11-dev to 3.11

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,14 +76,14 @@ jobs:
       matrix:
         # YAML parse `3.10` to `3.1`, so we have to add quotes for `'3.10'`, see also:
         # https://github.com/actions/setup-python/issues/160#issuecomment-724485470
-        python-version: [3.6, 3.7, 3.8, 3.9, '3.10', 3.11-dev]
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
         os: [ubuntu-latest, macOS-latest, windows-latest]
         # Skip because dependence [py4j](https://pypi.org/project/py4j/) not work on those environments
         exclude:
           - os: windows-latest
             python-version: '3.10'
           - os: windows-latest
-            python-version: 3.11-dev
+            python-version: 3.11
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/setup.py
+++ b/setup.py
@@ -141,8 +141,8 @@ setup(
         "taskflow",
     ],
     project_urls={
-        "Homepage": "https://dolphinscheduler.apache.org",
-        "Documentation": "https://dolphinscheduler.apache.org/python/dev/index.html",
+        "Homepage": "https://dolphinscheduler.apache.org/python/main/index.html",
+        "Documentation": "https://dolphinscheduler.apache.org/python/main/index.html",
         "Source": "https://github.com/apache/dolphinscheduler-sdk-python",
         "Issue Tracker": "https://github.com/apache/dolphinscheduler-sdk-python/issues",
         "Twitter": "https://twitter.com/dolphinschedule",


### PR DESCRIPTION
<!--Thanks for you contribute to Apache DolphinScheduler Python API, You can see more detail about contributing in https://github.com/apache/dolphinscheduler-sdk-python/DEVELOP.md .-->

## Brief Summary of The Change

<!--Please include `fixes: #XXXX(ISSUE_NUMBER)` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `related: #XXXX(ISSUE_NUMBER)`.-->

python 3.11 release at Oct. 24, 2022. see detail in https://www.python.org/downloads/release/python-3110/

## Pull Request checklist

I confirm that the following checklist has been completed.

- [x] Add/Change **test cases** for the changes.
- [x] Add/Change the related **documentation**, should also change `docs/source/config.rst` when you change file `default_config.yaml`.
- [x] (Optional) Add your change to `UPDATING.md` when it is an incompatible change.
