### PR TITLE
[feat] Mark workflow timeout as type timedelta

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ under the License.
 [![Twitter Follow](https://img.shields.io/twitter/follow/dolphinschedule.svg?style=social&label=Follow)](https://twitter.com/dolphinschedule)
 [![Slack Status](https://img.shields.io/badge/slack-join_chat-white.svg?logo=slack&style=social)](https://s.apache.org/dolphinscheduler-slack)
 
-**PyDolphinScheduler** is python API for [Apache DolphinScheduler](https://dolphinscheduler.apache.org/en-us/index.html),
+**PyDolphinScheduler** is python API for [Apache DolphinScheduler](https://dolphinscheduler.apache.org),
 which allow you definition your workflow by python code, aka workflow-as-codes.
 
 ## Quick Start
@@ -69,7 +69,7 @@ docker run --name dolphinscheduler-standalone-server -p 12345:12345 -p 25333:253
 
 After the container is started, you can access the DolphinScheduler UI via http://localhost:12345/dolphinscheduler.
 For more way to start DolphinScheduler and the more detail about DolphinScheduler, please refer to
-[DolphinScheduler](https://dolphinscheduler.apache.org/en-us/docs/latest/user_doc/about/introduction.html)
+[DolphinScheduler](https://dolphinscheduler.apache.org/#/en-us/docs/3.1.2/guide/start/quick-start)
 
 ### Run a simple example
 
@@ -92,7 +92,7 @@ python ./tutorial.py
 After that, a new workflow will be created by PyDolphinScheduler, and you can see it in DolphinScheduler web
 UI's Project Management page. It will trigger the workflow automatically, so you can see the workflow running
 in DolphinScheduler web UI's Workflow Instance page too. For more detail about any function about DolphinScheduler
-Project Management, please refer to [DolphinScheduler Project Management](https://dolphinscheduler.apache.org/en-us/docs/latest/user_doc/guide/project/project-list.html)
+Project Management, please refer to [DolphinScheduler Workflow](https://dolphinscheduler.apache.org/#/en-us/docs/3.1.2/guide/project/workflow-definition)
 
 ## Documentation
 

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -24,6 +24,7 @@ It started after version 2.0.5 released
 
 ## Main
 
+* Change Task attr ``timeout`` type from int to timedelta and use timeout determine attr ``timeout_flag`` value ([#41](https://github.com/apache/dolphinscheduler-sdk-python/pull/41)) 
 * Remove the spark version of spark task ([#11860](https://github.com/apache/dolphinscheduler/pull/11860)).
 * Change class name from process definition to workflow ([#26](https://github.com/apache/dolphinscheduler-sdk-python/pull/26))
   * Deprecated class `ProcessDefinition` to `Workflow`

--- a/examples/yaml_define/MoreConfiguration.yaml
+++ b/examples/yaml_define/MoreConfiguration.yaml
@@ -34,7 +34,6 @@ tasks:
     delay_time: 20
     fail_retry_times: 30
     fail_retry_interval: 5
-    timeout_flag: "CLOSE"
     timeout: 60
     local_params:
       - { "prop": "n", "direct": "IN", "type": "VARCHAR", "value": "${n}" }

--- a/src/pydolphinscheduler/constants.py
+++ b/src/pydolphinscheduler/constants.py
@@ -38,7 +38,8 @@ class TaskFlag(str):
 class TaskTimeoutFlag(str):
     """Constants for task timeout flag."""
 
-    CLOSE = "CLOSE"
+    OFF = "CLOSE"
+    ON = "OPEN"
 
 
 class TaskType(str):

--- a/src/pydolphinscheduler/utils/date.py
+++ b/src/pydolphinscheduler/utils/date.py
@@ -17,7 +17,8 @@
 
 """Date util function collections."""
 
-from datetime import datetime
+from datetime import datetime, timedelta
+from math import ceil
 
 from pydolphinscheduler.constants import Delimiter, Time
 
@@ -80,3 +81,14 @@ def conv_from_str(src: str) -> datetime:
             )
     else:
         raise NotImplementedError("%s could not be convert to datetime for now.", src)
+
+
+def timedelta2timeout(td: timedelta) -> int:
+    """Convert timedelta to workflow timeout, only keep ``math.ceil`` integer in minutes.
+
+    Because dolphinscheduler timeout attribute only supported in minutes, so we need to convert timedelta
+    into minutes. And will use ``math.ceil`` to keep it integer and not less than 1 if it configured.
+
+    :param td: timedelta object want to convert
+    """
+    return ceil(td.total_seconds() / 60)

--- a/tests/core/test_task.py
+++ b/tests/core/test_task.py
@@ -18,7 +18,8 @@
 """Test Task class function."""
 import logging
 import re
-from typing import Set
+from datetime import timedelta
+from typing import Set, Tuple
 from unittest.mock import PropertyMock, patch
 
 import pytest
@@ -98,6 +99,27 @@ def test__get_attr(addition: Set, ignore: Set, expect: Set):
     task._task_custom_attr = addition
     task._task_ignore_attr = ignore
     assert task._get_attr() == expect
+
+
+@pytest.mark.parametrize(
+    "value, expect",
+    [
+        (None, (0, "CLOSE")),
+        (timedelta(seconds=0.1), (1, "OPEN")),
+        (timedelta(seconds=61), (2, "OPEN")),
+        (timedelta(seconds=0), (0, "CLOSE")),
+        (timedelta(minutes=1.3), (2, "OPEN")),
+    ],
+)
+def test_task_timeout(value: timedelta, expect: Tuple[int, str]):
+    """Test task timout attribute."""
+    task = TestTask(
+        name="test-get-attr",
+        task_type="test",
+        timeout=value,
+    )
+    assert task.timeout == expect[0]
+    assert task.timeout_flag == expect[1]
 
 
 @pytest.mark.parametrize(

--- a/tests/utils/test_date.py
+++ b/tests/utils/test_date.py
@@ -17,11 +17,17 @@
 
 """Test utils.date module."""
 
-from datetime import datetime
+from datetime import datetime, timedelta
+from typing import Dict
 
 import pytest
 
-from pydolphinscheduler.utils.date import FMT_STD, conv_from_str, conv_to_schedule
+from pydolphinscheduler.utils.date import (
+    FMT_STD,
+    conv_from_str,
+    conv_to_schedule,
+    timedelta2timeout,
+)
 
 curr_date = datetime.now()
 
@@ -76,3 +82,22 @@ def test_conv_from_str_not_impl(src: str) -> None:
         NotImplementedError, match=".*? could not be convert to datetime for now."
     ):
         conv_from_str(src)
+
+
+@pytest.mark.parametrize(
+    "src, expect",
+    [
+        ({"seconds": 1}, 1),
+        ({"seconds": 60}, 1),
+        ({"seconds": 62}, 2),
+        ({"minutes": 1}, 1),
+        ({"minutes": 1.1}, 2),
+        ({"minutes": 2}, 2),
+        ({"hours": 1}, 60),
+        ({"hours": 1.3}, 78),
+    ],
+)
+def test_timedelta2timeout(src: Dict, expect: int) -> None:
+    """Test function timedelta2timeout."""
+    td = timedelta(**src)
+    assert timedelta2timeout(td) == expect, f"Test case {td} not expect to {expect}."


### PR DESCRIPTION
<!--Thanks for you contribute to Apache DolphinScheduler Python API, You can see more detail about contributing in https://github.com/apache/dolphinscheduler-sdk-python/DEVELOP.md .-->

## Brief Summary of The Change

<!--Please include `fixes: #XXXX(ISSUE_NUMBER)` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `related: #XXXX(ISSUE_NUMBER)`.-->

* Change task parameter ``timeout`` from int to timedelta
* Set attribute ``timeout_flag`` base on ``timeout`` value

## Pull Request checklist

I confirm that the following checklist has been completed.

- [x] Add/Change **test cases** for the changes.
- [x] Add/Change the related **documentation**, should also change `docs/source/config.rst` when you change file `default_config.yaml`.
- [x] (Optional) Add your change to `UPDATING.md` when it is an incompatible change.
