### PR TITLE
fix: sql task pre post stm typing and add example

### DIFF
--- a/docs/source/tasks/sql.rst
+++ b/docs/source/tasks/sql.rst
@@ -18,6 +18,58 @@
 SQL
 ===
 
+An example for SQL task, including how to use it and the detail of it parameters.
+
+This task type can execute multiple type of database SQL, which includes
+
+- MySQL
+- PostgreSQL
+- Oracle
+- SQL Server
+- DB2
+- Hive
+- Presto
+- Trino
+- ClickHouse
+
+Example
+-------
+
+.. literalinclude:: ../../../src/pydolphinscheduler/examples/task_sql_example.py
+   :start-after: [start workflow_declare]
+   :end-before: [end workflow_declare]
+
+You can see that SQL task support three ways to declare SQL, which are
+
+- Bare SQL: Put bare SQL statement in the ``sql`` parameter, such as ``select * from table1``.
+
+   .. literalinclude:: ../../../src/pydolphinscheduler/examples/task_sql_example.py
+      :start-after: [start bare_sql_desc]
+      :end-before: [end bare_sql_desc]
+
+- SQL Files: .
+
+   .. literalinclude:: ../../../src/pydolphinscheduler/examples/task_sql_example.py
+      :start-after: [start sql_file_desc]
+      :end-before: [end sql_file_desc]
+
+If you want to do some preparation before executing SQL, or do some clean up after executing SQL, you can use 
+``pre_statements`` and ``post_statements`` parameters to do that. Both ``pre_statements`` and ``post_statements``
+support one or multiple statements, you can assign type sequence of SQL statements to them if you want to execute
+multiple statements. But if you only need to execute one statement, you can assign a string to them.
+
+   .. literalinclude:: ../../../src/pydolphinscheduler/examples/task_sql_example.py
+      :start-after: [start sql_with_pre_post_desc]
+      :end-before: [end sql_with_pre_post_desc]
+
+.. note::
+
+   Parameter ``pre_statements`` and ``post_statements`` only support not query statements, such as ``create table``,
+   ``drop table``, ``update table`` currently. And also it only support bare SQL instead of SQL files now.
+
+Dive Into
+---------
+
 .. automodule:: pydolphinscheduler.tasks.sql
 
 

--- a/src/pydolphinscheduler/examples/ext/example.sql
+++ b/src/pydolphinscheduler/examples/ext/example.sql
@@ -1,0 +1,3 @@
+select *
+from resource_plugin
+where id = 1

--- a/src/pydolphinscheduler/examples/task_sql_example.py
+++ b/src/pydolphinscheduler/examples/task_sql_example.py
@@ -1,0 +1,66 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# [start workflow_declare]
+
+"""A example workflow for task SQL."""
+from pathlib import Path
+
+from pydolphinscheduler.core.workflow import Workflow
+from pydolphinscheduler.resources_plugin import Local
+from pydolphinscheduler.tasks.sql import Sql, SqlType
+
+with Workflow(
+    name="task_sql_example",
+) as workflow:
+    # [start bare_sql_desc]
+    bare_sql = Sql(
+        name="bare_sql",
+        datasource_name="metadata",
+        sql="select * from t_ds_version",
+    )
+    # [end bare_sql_desc]
+    # [start sql_file_desc]
+    sql_file = Sql(
+        name="sql_file",
+        datasource_name="metadata",
+        sql="ext/example.sql",
+        sql_type=SqlType.SELECT,
+        resource_plugin=Local(prefix=str(Path(__file__).parent)),
+    )
+    # [end sql_file_desc]
+    # [start sql_with_pre_post_desc]
+    sql_with_pre_post = Sql(
+        name="sql_with_pre_post",
+        datasource_name="metadata",
+        sql="select * from t_ds_version",
+        pre_statements=[
+            "update table_one set version = '1.3.6'",
+            "delete from table_two where version = '1.3.6'",
+        ],
+        post_statements="update table_one set version = '3.0.0'",
+    )
+    # [end sql_with_pre_post_desc]
+
+    bare_sql >> [
+        sql_file,
+        sql_with_pre_post,
+    ]
+
+    workflow.submit()
+
+# [end workflow_declare]

--- a/tests/tasks/test_sql.py
+++ b/tests/tasks/test_sql.py
@@ -41,6 +41,30 @@ def setup_crt_first():
 
 
 @pytest.mark.parametrize(
+    "stm, expected",
+    [
+        ("select * from t_ds_version", ["select * from t_ds_version"]),
+        (None, []),
+        (
+            ["select * from table1", "select * from table2"],
+            ["select * from table1", "select * from table2"],
+        ),
+        (
+            ("select * from table1", "select * from table2"),
+            ["select * from table1", "select * from table2"],
+        ),
+        (
+            {"select * from table1", "select * from table2"},
+            ["select * from table1", "select * from table2"],
+        ),
+    ],
+)
+def test_get_stm_list(stm, expected) -> None:
+    """Test static function get_stm_list."""
+    assert sorted(Sql.get_stm_list(stm)) == sorted(expected)
+
+
+@pytest.mark.parametrize(
     "sql, param_sql_type, sql_type",
     [
         ("select 1", None, SqlType.SELECT),

--- a/tests/testing/constants.py
+++ b/tests/testing/constants.py
@@ -22,7 +22,6 @@ import os
 # Record some task without example in directory `example`. Some of them maybe can not write example,
 # but most of them just without adding by mistake, and we should add it later.
 task_without_example = {
-    "sql",
     "http",
     "sub_workflow",
     "python",
@@ -38,6 +37,7 @@ ignore_exec_examples = {
     "task_spark_example",
     # TODO activate it when dolphinscheduler default resource center is local file
     "multi_resources_example",
+    "task_sql_example",
 }
 
 # pydolphinscheduler environment home


### PR DESCRIPTION
<!--Thanks for you contribute to Apache DolphinScheduler Python API, You can see more detail about contributing in https://github.com/apache/dolphinscheduler-sdk-python/DEVELOP.md .-->

## Brief Summary of The Change

<!--Please include `fixes: #XXXX(ISSUE_NUMBER)` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `related: #XXXX(ISSUE_NUMBER)`.-->

Correct pre and post statement type, and also supprt
string type, and also add example of sql type

## Pull Request checklist

I confirm that the following checklist has been completed.

- [x] Add/Change **test cases** for the changes.
- [x] Add/Change the related **documentation**, should also change `docs/source/config.rst` when you change file `default_config.yaml`.
- [x] (Optional) Add your change to `UPDATING.md` when it is an incompatible change.
