### PR TITLE
feat: Add stmdency handle @task decorate statement dependency

### DIFF
--- a/docs/source/tasks/func_wrap.rst
+++ b/docs/source/tasks/func_wrap.rst
@@ -15,10 +15,59 @@
    specific language governing permissions and limitations
    under the License.
 
-Python Function Wrapper
-=======================
+Python Function Decorate
+========================
 
-A decorator covert Python function into pydolphinscheduler's task.
+A decorator covert Python function into pydolphinscheduler's task. Python function decorator use decorate
+:code:`@task` from :code:`from pydolphinscheduler.tasks.func_wrap import task` to convert Python function into
+a single Python task of dolphinscheduler.
+
+Because we have to covert the whole Python definition into multiple Python task in dolphinscheduler, and all of
+the seperated Python task will be executed in the different Python process, so we need to separate not only the
+python function code, but also the all variables and the imported modules related to decorated function.
+
+For example, we decorated function ``depend_import`` in definition
+
+.. code-block:: python
+
+   import time
+   
+   @task
+   def depend_import():
+       time.sleep(2)
+
+and we can see functon ``depend_import`` depend on other modules, it use :code:`time.sleep(2)` from module :code:`time`
+to sleep 2 seconds. So when we want to separate this function into dolphinscheduler task, need to include the imported
+:code:`time` module.
+
+which means we not only post code
+
+.. code-block:: python
+
+   def depend_import():
+       time.sleep(2)
+
+   depend_import()
+
+to dolphinscheduler Python task, we post the dependencies of this function as well, so you will see this in
+dolphinscheduler Python task to make it work. And if you use the global variables or other function in the
+decorated function, it will also including them as well.
+
+.. code-block:: python
+
+   import time
+
+   def depend_import():
+       time.sleep(2)
+
+   depend_import()
+
+
+.. note::
+
+   We use third party library `stmdency <https://pypi.org/project/stmdency>`_ to get the dependencies statement
+   of current function, so if you find some unexpected behavior you can report bug to `apache-dolphinscheduler`
+   or `stmdency`.
 
 Example
 -------

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ prod = [
     "click>=8.0.0",
     "py4j~=0.10",
     "ruamel.yaml",
+    "stmdency>=0.0.2",
 ]
 
 build = [

--- a/src/pydolphinscheduler/examples/tutorial_decorator.py
+++ b/src/pydolphinscheduler/examples/tutorial_decorator.py
@@ -30,6 +30,8 @@ task_parent -->                        -->  task_union
 it will instantiate and run all the task it have.
 """
 
+import time
+
 # [start tutorial]
 # [start package_import]
 # Import Workflow object to define your workflow attributes
@@ -40,30 +42,44 @@ from pydolphinscheduler.tasks.func_wrap import task
 
 # [end package_import]
 
+scope_global = "global-var"
+
 
 # [start task_declare]
 @task
-def task_parent():
+def print_something():
     """First task in this workflow."""
-    print("echo hello pydolphinscheduler")
+    print("hello python function wrap task")
 
 
 @task
-def task_child_one():
-    """Child task will be run parallel after task ``task_parent`` finished."""
-    print("echo 'child one'")
+def depend_import():
+    """Depend on import module."""
+    time.sleep(2)
 
 
 @task
-def task_child_two():
-    """Child task will be run parallel after task ``task_parent`` finished."""
-    print("echo 'child two'")
+def depend_global_var():
+    """Depend on global var."""
+    print(f"Use global variable {scope_global}")
 
 
 @task
-def task_union():
-    """Last task in this workflow."""
-    print("echo union")
+def depend_local_var():
+    """Depend on local variable."""
+    scope_global = "local"
+    print(f"Use local variable overwrite global {scope_global}")
+
+
+def foo():
+    """Call in other task."""
+    print("this is a global function")
+
+
+@task
+def depend_func():
+    """Depend on global function."""
+    foo()
 
 
 # [end task_declare]
@@ -78,13 +94,13 @@ with Workflow(
     # [end workflow_declare]
 
     # [start task_relation_declare]
-    task_group = [task_child_one(), task_child_two()]
-    task_parent().set_downstream(task_group)
+    task_group = [depend_import(), depend_global_var()]
+    print_something().set_downstream(task_group)
 
-    task_union() << task_group
+    task_group >> depend_local_var() >> depend_func()
     # [end task_relation_declare]
 
     # [start submit_or_run]
-    workflow.run()
+    workflow.submit()
     # [end submit_or_run]
 # [end tutorial]

--- a/src/pydolphinscheduler/tasks/python.py
+++ b/src/pydolphinscheduler/tasks/python.py
@@ -80,10 +80,6 @@ class Python(Task):
             pattern = re.compile("^def (\\w+)\\(")
             find = pattern.findall(definition)
             if not find:
-                log.warning(
-                    "Python definition is simple script instead of function, with value %s",
-                    definition,
-                )
                 return definition
             # Keep function str and function callable always have one blank line
             func_str = (

--- a/tests/tasks/test_func_wrap.py
+++ b/tests/tasks/test_func_wrap.py
@@ -49,7 +49,10 @@ def test_single_task_outside(mock_code):
 
     pd_task = workflow.tasks[12345]
     assert pd_task.name == "foo"
-    assert pd_task.raw_script == "def foo():\n    print(TASK_NAME)\nfoo()"
+    assert (
+        pd_task.raw_script
+        == 'TASK_NAME = "test_task"\n\n\ndef foo():\n    print(TASK_NAME)\nfoo()'
+    )
 
 
 @patch(
@@ -70,7 +73,10 @@ def test_single_task_inside(mock_code):
 
     pd_task = workflow.tasks[12345]
     assert pd_task.name == "foo"
-    assert pd_task.raw_script == "def foo():\n    print(TASK_NAME)\nfoo()"
+    assert (
+        pd_task.raw_script
+        == 'TASK_NAME = "test_task"\n\n\ndef foo():\n    print(TASK_NAME)\nfoo()'
+    )
 
 
 @patch(


### PR DESCRIPTION
<!--Thanks for you contribute to Apache DolphinScheduler Python API, You can see more detail about contributing in https://github.com/apache/dolphinscheduler-sdk-python/DEVELOP.md .-->

## Brief Summary of The Change

<!--Please include `fixes: #XXXX(ISSUE_NUMBER)` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `related: #XXXX(ISSUE_NUMBER)`.-->

Before this, we can not handle statement dependency in task decorate, including global variable, other function call or import module
This patch we introduce stmdency to handle those issue and make it

## Pull Request checklist

I confirm that the following checklist has been completed.

- [x] Add/Change **test cases** for the changes.
- [x] Add/Change the related **documentation**, should also change `docs/source/config.rst` when you change file `default_config.yaml`.
- [x] (Optional) Add your change to `UPDATING.md` when it is an incompatible change.
