### PR TITLE
feat: Add online_schedule for workflow control schedule state

### DIFF
--- a/src/pydolphinscheduler/core/workflow.py
+++ b/src/pydolphinscheduler/core/workflow.py
@@ -57,6 +57,11 @@ class Workflow(Base):
 
     TODO: maybe we should rename this class, currently use DS object name.
 
+    :param online_schedule: Whether the online workflow is schedule. It will be automatically configured
+        according to :param:``schedule`` configuration. If the :param:``schedule`` is assigned with valid
+        value, :param:``online_schedule`` will be set to ``True``. But you can also manually specify
+        :param:``online_schedule``. For example if you only want to set the workflow :param:``schedule`` but
+        do not want to online the workflow schedule, you can set :param:``online_schedule`` to ``False``.
     :param execution_type: Decision which behavior to run when workflow have multiple instances.
         when workflow schedule interval is too short, it may cause multiple instances run at the
         same time. We can use this parameter to control the behavior about how to run those workflows
@@ -115,6 +120,7 @@ class Workflow(Base):
         name: str,
         description: Optional[str] = None,
         schedule: Optional[str] = None,
+        online_schedule: Optional[bool] = None,
         start_time: Optional[Union[str, datetime]] = None,
         end_time: Optional[Union[str, datetime]] = None,
         timezone: Optional[str] = configuration.WORKFLOW_TIME_ZONE,
@@ -143,6 +149,12 @@ class Workflow(Base):
                 self._EXPECT_SCHEDULE_CHAR_NUM,
                 schedule,
             )
+
+        #  handle workflow schedule state according to init value
+        if self.schedule and online_schedule is None:
+            self.online_schedule = True
+        else:
+            self.online_schedule = online_schedule or False
         self._start_time = start_time
         self._end_time = end_time
         self.timezone = timezone
@@ -440,6 +452,7 @@ class Workflow(Base):
             json.dumps(self.task_relation_json),
             json.dumps(self.task_definition_json),
             json.dumps(self.schedule_json) if self.schedule_json else None,
+            self.online_schedule,
             None,
         )
         return self._workflow_code

--- a/src/pydolphinscheduler/java_gateway.py
+++ b/src/pydolphinscheduler/java_gateway.py
@@ -264,6 +264,7 @@ class GatewayEntryPoint:
         task_relation_json: str,
         task_definition_json: str,
         schedule: Optional[str] = None,
+        online_schedule: Optional[bool] = None,
         other_params_json: Optional[str] = None,
     ):
         """Create or update workflow through java gateway."""
@@ -274,6 +275,7 @@ class GatewayEntryPoint:
             description,
             global_params,
             schedule,
+            online_schedule,
             warning_type,
             warning_group_id,
             timeout,

--- a/tests/core/test_workflow.py
+++ b/tests/core/test_workflow.py
@@ -124,6 +124,22 @@ def test_set_release_state(value, expect):
 
 
 @pytest.mark.parametrize(
+    "value,expect",
+    [
+        ({}, False),
+        ({"schedule": "0 0 0 * * ? *"}, True),
+        ({"schedule": "0 0 0 * * ? *", "online_schedule": False}, False),
+    ],
+)
+def test_set_online_schedule(value, expect):
+    """Test workflow set online_schedule attributes."""
+    with Workflow(TEST_WORKFLOW_NAME, **value) as workflow:
+        assert (
+            getattr(workflow, "online_schedule") == expect
+        ), f"Workflow attribute online_schedule do not in expect value with case {value}."
+
+
+@pytest.mark.parametrize(
     "value",
     [
         "oneline",


### PR DESCRIPTION
<!--Thanks for you contribute to Apache DolphinScheduler Python API, You can see more detail about contributing in https://github.com/apache/dolphinscheduler-sdk-python/DEVELOP.md .-->

## Brief Summary of The Change

<!--Please include `fixes: #XXXX(ISSUE_NUMBER)` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `related: #XXXX(ISSUE_NUMBER)`.-->

Add parameter `online_schedule` to control whether the schedule is online or not

close: #71

## Pull Request checklist

I confirm that the following checklist has been completed.

- [x] Add/Change **test cases** for the changes.
- [x] Add/Change the related **documentation**, should also change `docs/source/config.rst` when you change file `default_config.yaml`.
- [x] (Optional) Add your change to `UPDATING.md` when it is an incompatible change.
