### PR TITLE
use_resource_file_like_web

### DIFF
--- a/src/pydolphinscheduler/__init__.py
+++ b/src/pydolphinscheduler/__init__.py
@@ -17,4 +17,4 @@
 
 """Init root of pydolphinscheduler."""
 
-__version__ = "4.1.0-dev"
+__version__ = "4.0.3"

--- a/src/pydolphinscheduler/configuration.py
+++ b/src/pydolphinscheduler/configuration.py
@@ -184,7 +184,7 @@ USER_PASSWORD = os.environ.get(
     "PYDS_USER_PASSWORD", configs.get("default.user.password")
 )
 USER_EMAIL = os.environ.get("PYDS_USER_EMAIL", configs.get("default.user.email"))
-USER_TENANT = os.environ.get("PYDS_USER_TENANT", configs.get("default.user.tenant"))
+USER_TENANT = os.environ.get("PYDS_USER_STATE", configs.get("default.user.tenant"))
 USER_PHONE = str(os.environ.get("PYDS_USER_PHONE", configs.get("default.user.phone")))
 USER_STATE = get_int(
     os.environ.get("PYDS_USER_STATE", configs.get("default.user.state"))

--- a/src/pydolphinscheduler/constants.py
+++ b/src/pydolphinscheduler/constants.py
@@ -35,13 +35,6 @@ class TaskFlag(str):
     NO = "NO"
 
 
-class IsCache(str):
-    """Constants for Cache."""
-
-    YES = "YES"
-    NO = "NO"
-
-
 class TaskTimeoutFlag(str):
     """Constants for task timeout flag."""
 
@@ -120,7 +113,7 @@ class ResourceKey(str):
     """Constants for key of resource."""
 
     NAME = "resourceName"
-
+    ID = "id"
 
 class Symbol(str):
     """Constants for symbol."""

--- a/src/pydolphinscheduler/core/resource.py
+++ b/src/pydolphinscheduler/core/resource.py
@@ -58,6 +58,9 @@ class Resource(Base):
     def get_fullname_from_database(self):
         """Get resource fullname from java gateway."""
         return self.get_info_from_database().getFullName()
+    
+    def get_id_from_database(self):
+        return self.get_info_from_database().getId()
 
     def create_or_update_resource(self):
         """Create or update resource via java gateway."""
@@ -68,5 +71,6 @@ class Resource(Base):
         return gateway.create_or_update_resource(
             self.user_name,
             self.name,
+            self.description,
             self.content,
         )

--- a/src/pydolphinscheduler/default_config.yaml
+++ b/src/pydolphinscheduler/default_config.yaml
@@ -39,16 +39,16 @@ java_gateway:
 default:
   # Default value for dolphinscheduler's user object
   user:
-    name: userPythonGateway
-    password: userPythonGateway
+    name: admin
+    password: dolphinscheduler123
     email: userPythonGateway@dolphinscheduler.com
-    tenant: tenant_pydolphin
+    tenant: default
     phone: 11111111111
     state: 1
   # Default value for dolphinscheduler's workflow object
   workflow:
     project: project-pydolphin
-    user: userPythonGateway
+    user: admin
     queue: queuePythonGateway
     worker_group: default
     # Release state of workflow, default value is ``online`` which mean setting workflow online when it submits

--- a/src/pydolphinscheduler/examples/tutorial.py
+++ b/src/pydolphinscheduler/examples/tutorial.py
@@ -30,38 +30,24 @@ task_parent -->                        -->  task_union
 it will instantiate and run all the task it have.
 """
 
-# [start tutorial]
-# [start package_import]
-# Import Workflow object to define your workflow attributes
 from pydolphinscheduler.core.workflow import Workflow
 
-# Import task Shell object cause we would create some shell tasks later
 from pydolphinscheduler.tasks.shell import Shell
 
-# [end package_import]
 
-# [start workflow_declare]
 with Workflow(
     name="tutorial",
     schedule="0 0 0 * * ? *",
     start_time="2021-01-01",
 ) as workflow:
-    # [end workflow_declare]
-    # [start task_declare]
     task_parent = Shell(name="task_parent", command="echo hello pydolphinscheduler")
     task_child_one = Shell(name="task_child_one", command="echo 'child one'")
     task_child_two = Shell(name="task_child_two", command="echo 'child two'")
     task_union = Shell(name="task_union", command="echo union")
-    # [end task_declare]
 
-    # [start task_relation_declare]
     task_group = [task_child_one, task_child_two]
     task_parent.set_downstream(task_group)
 
     task_union << task_group
-    # [end task_relation_declare]
 
-    # [start submit_or_run]
     workflow.run()
-    # [end submit_or_run]
-# [end tutorial]

--- a/src/pydolphinscheduler/java_gateway.py
+++ b/src/pydolphinscheduler/java_gateway.py
@@ -124,9 +124,13 @@ class GatewayEntryPoint:
         """Get resources file info through java gateway."""
         return self.gateway.entry_point.getResourcesFileInfo(program_type, main_package)
 
-    def create_or_update_resource(self, user_name: str, name: str, content: str):
+    def create_or_update_resource(
+        self, user_name: str, name: str, description: str, content: str
+    ):
         """Create or update resource through java gateway."""
-        return self.gateway.entry_point.createOrUpdateResource(user_name, name, content)
+        return self.gateway.entry_point.createOrUpdateResource(
+            user_name, name, description, content
+        )
 
     def query_resources_file_info(self, user_name: str, name: str):
         """Get resources file info through java gateway."""

--- a/src/pydolphinscheduler/resources_plugin/hdfs.py
+++ b/src/pydolphinscheduler/resources_plugin/hdfs.py
@@ -1,0 +1,73 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""DolphinScheduler HDFS resource plugin."""
+
+from typing import Optional
+from urllib.parse import urljoin
+
+from hdfs import InsecureClient
+
+from pydolphinscheduler.constants import Symbol
+from pydolphinscheduler.core.resource_plugin import ResourcePlugin
+from pydolphinscheduler.resources_plugin.base.bucket import Bucket, HDFSFileInfo
+
+
+class HDFS(ResourcePlugin, Bucket):
+    """HDFS object, declare HDFS resource plugin for task and workflow to dolphinscheduler.
+
+    :param prefix: A string representing the prefix of HDFS.
+    :param hdfs_uri: A string representing the URI of HDFS, e.g., 'hdfs://localhost:8020'.
+    """
+
+    def __init__(
+        self,
+        prefix: str,
+        hdfs_uri: Optional[str] = None,
+        *args,
+        **kwargs
+    ):
+        super().__init__(prefix, *args, **kwargs)
+        self.hdfs_uri = hdfs_uri
+
+    _bucket_file_info: Optional[HDFSFileInfo] = None
+
+    def get_bucket_file_info(self, path: str):
+        """Get file information from the file url, like repository name, user, branch, and file path."""
+        elements = path.split(Symbol.SLASH)
+        self.get_index(path, Symbol.SLASH, 3)
+        self._bucket_file_info = HDFSFileInfo(
+            hdfs_uri=self.hdfs_uri,
+            file_path=Symbol.SLASH.join(
+                str(elements[i]) for i in range(3, len(elements))
+            ),
+        )
+
+    def read_file(self, suf: str):
+        """Get the content of the file.
+
+        The address of the file is the prefix of the resource plugin plus the parameter suf.
+        """
+        path = urljoin(self.prefix, suf)
+        self.get_bucket_file_info(path)
+        hdfs_uri = self._bucket_file_info.hdfs_uri
+        file_path = self._bucket_file_info.file_path
+        client = InsecureClient(hdfs_uri)
+        with client.read(file_path) as reader:
+            content = reader.read().decode("utf-8")
+        return content
+

--- a/src/pydolphinscheduler/tasks/shell.py
+++ b/src/pydolphinscheduler/tasks/shell.py
@@ -49,10 +49,14 @@ class Shell(Task):
     _task_custom_attr = {
         "raw_script",
     }
-
     ext: set = {".sh", ".zsh"}
     ext_attr: str = "_raw_script"
 
     def __init__(self, name: str, command: str, *args, **kwargs):
         self._raw_script = command
         super().__init__(name, TaskType.SHELL, *args, **kwargs)
+        #for arg in args:
+            #print("im!arg!!",arg)
+        #for arg in kwargs:
+            #print("im!!!!kwargs!!!",arg)
+            

--- a/src/pydolphinscheduler/version_ext
+++ b/src/pydolphinscheduler/version_ext
@@ -1,1 +1,1 @@
-dolphinscheduler>=3.2.0
+dolphinscheduler>=3.1.5, <3.1.7


### PR DESCRIPTION
<!--Thanks for you contribute to Apache DolphinScheduler Python API, You can see more detail about contributing in https://github.com/apache/dolphinscheduler-sdk-python/DEVELOP.md .-->

## Brief Summary of The Change

<!--Please include `fixes: #XXXX(ISSUE_NUMBER)` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `related: #XXXX(ISSUE_NUMBER)`.-->

## Pull Request checklist


I confirm that the following checklist has been completed.

- [ ] Add/Change **test cases** for the changes.
- [ ] Add/Change the related **documentation**, should also change `docs/source/config.rst` when you change file `default_config.yaml`.
- [ ] (Optional) Add your change to `UPDATING.md` when it is an incompatible change.

## What I do
I noticed that when pydolphinscheduler was working with resources in the resource center, it was not similar to a reference file on a web page, but was reading in the file and adding it to commands. Analyzing the reference file format on the web page, we find that ResourceList in taskDefinitionList stores the id of the Resource, not the name. So I've made some changes here, and I've made some changes to how resources are used.

This is the effect of pydolphinscheduler：
![image](https://github.com/apache/dolphinscheduler-sdk-python/assets/82716144/289857b0-4df2-40f7-8d0e-d1ea6f64ebb0)

This is the effect of the dolphinscheduler website：
![image](https://github.com/apache/dolphinscheduler-sdk-python/assets/82716144/78707d2f-dd97-4307-9a51-56c69aec3fb0)


