### PR TITLE
[impv] Change the parameter types of task and workflow to Union[timedelta, int]

### DIFF
--- a/src/pydolphinscheduler/core/task.py
+++ b/src/pydolphinscheduler/core/task.py
@@ -247,15 +247,6 @@ class Task(Base):
         """Set attribute workflow."""
         self._workflow = workflow
 
-    @staticmethod
-    def _parse_timeout(val: Any) -> Any:
-        if val is None or isinstance(val, timedelta):
-            return timedelta2timeout(val) if val else 0
-        elif val >= 0:
-            return val
-        else:
-            raise PyDSParamException("The timeout value cannot be negative")
-
     @property
     def timeout(self) -> int:
         """Get attribute timeout."""

--- a/src/pydolphinscheduler/core/task.py
+++ b/src/pydolphinscheduler/core/task.py
@@ -69,10 +69,10 @@ class TaskRelation(Base):
     }
 
     def __init__(
-            self,
-            pre_task_code: int,
-            post_task_code: int,
-            name: Optional[str] = None,
+        self,
+        pre_task_code: int,
+        post_task_code: int,
+        name: Optional[str] = None,
     ):
         super().__init__(name)
         self.pre_task_code = pre_task_code
@@ -366,8 +366,8 @@ class Task(Base):
                 setattr(self, self.ext_attr.lstrip(Symbol.UNDERLINE), content)
             else:
                 if self.resource_plugin is not None or (
-                        self.workflow is not None
-                        and self.workflow.resource_plugin is not None
+                    self.workflow is not None
+                    and self.workflow.resource_plugin is not None
                 ):
                     index = _ext_attr.rfind(Symbol.POINT)
                     if index != -1:
@@ -403,7 +403,7 @@ class Task(Base):
         return self
 
     def _set_deps(
-            self, tasks: Union["Task", Sequence["Task"]], upstream: bool = True
+        self, tasks: Union["Task", Sequence["Task"]], upstream: bool = True
     ) -> None:
         """
         Set parameter tasks dependent to current task.
@@ -483,9 +483,9 @@ class Task(Base):
         return local_params
 
     def add_in(
-            self,
-            name: str,
-            value: Optional[Union[int, str, float, bool, BaseDataType]] = None,
+        self,
+        name: str,
+        value: Optional[Union[int, str, float, bool, BaseDataType]] = None,
     ):
         """Add input parameters.
 
@@ -503,9 +503,9 @@ class Task(Base):
         self._input_params[name] = value
 
     def add_out(
-            self,
-            name: str,
-            value: Optional[Union[int, str, float, bool, BaseDataType]] = None,
+        self,
+        name: str,
+        value: Optional[Union[int, str, float, bool, BaseDataType]] = None,
     ):
         """Add output parameters.
 

--- a/tests/core/test_task.py
+++ b/tests/core/test_task.py
@@ -20,7 +20,7 @@ import logging
 import re
 import warnings
 from datetime import timedelta
-from typing import Set, Tuple
+from typing import Set, Tuple, Union
 from unittest.mock import PropertyMock, patch
 
 import pytest
@@ -111,9 +111,13 @@ def test__get_attr(addition: Set, ignore: Set, expect: Set):
         (timedelta(seconds=61), (2, "OPEN")),
         (timedelta(seconds=0), (0, "CLOSE")),
         (timedelta(minutes=1.3), (2, "OPEN")),
+        (1, (1, "OPEN")),
+        (5, (5, "OPEN")),
+        (0, (0, "CLOSE")),
+        (None, (0, "CLOSE")),
     ],
 )
-def test_task_timeout(value: timedelta, expect: Tuple[int, str]):
+def test_task_timeout(value: Union[timedelta, int], expect: Tuple[int, str]):
     """Test task timout attribute."""
     task = TestTask(
         name="test-get-attr",

--- a/tests/core/test_workflow.py
+++ b/tests/core/test_workflow.py
@@ -17,8 +17,8 @@
 
 """Test workflow."""
 import warnings
-from datetime import datetime
-from typing import Any, List
+from datetime import datetime, timedelta
+from typing import Any, List, Union
 from unittest.mock import patch
 
 import pytest
@@ -90,7 +90,6 @@ def test_workflow_default_value(name, value):
         ("warning_type", str, "FAILURE"),
         ("warning_group_id", int, 1),
         ("execution_type", str, "PARALLEL"),
-        ("timeout", int, 1),
         ("param", dict, {"key": "value"}),
         (
             "resource_list",
@@ -106,6 +105,24 @@ def test_set_attr(name, cls, expect):
         assert (
             getattr(workflow, name) == expect
         ), f"Workflow set attribute `{name}` do not work expect"
+
+
+@pytest.mark.parametrize(
+    "value, expect",
+    [
+        (0, 0),
+        (5, 5),
+        (timedelta(seconds=60), 1),
+        (timedelta(seconds=61), 2),
+        (timedelta(seconds=360), 6),
+    ],
+)
+def test_workflow_timeout(value: Union[timedelta, int], expect: int):
+    """Test workflow timout attribute."""
+    with Workflow(TEST_WORKFLOW_NAME, timeout=value) as workflow:
+        assert (
+            workflow.timeout == expect
+        ), f"Workflow set attribute timeout expect {expect} but get {workflow.timeout}"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--Thanks for you contribute to Apache DolphinScheduler Python API, You can see more detail about contributing in https://github.com/apache/dolphinscheduler-sdk-python/DEVELOP.md .-->
## Purpose of the pull request

close #122 

## Brief Summary of The Change

<!--Please include `fixes: #XXXX(ISSUE_NUMBER)` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `related: #XXXX(ISSUE_NUMBER)`.-->

Change the parameter types of task and workflow to Union[timedelta, int]

## Pull Request checklist

I confirm that the following checklist has been completed.

- [ ] Add/Change **test cases** for the changes.
- [ ] Add/Change the related **documentation**, should also change `docs/source/config.rst` when you change file `default_config.yaml`.
- [ ] (Optional) Add your change to `UPDATING.md` when it is an incompatible change.
