### PR TITLE
chore: Drop support of py36 and py37

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,10 +57,10 @@ jobs:
     needs: license
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.7
+      - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.11
       - name: Install Dependences
         run: |
           python -m pip install --upgrade ${{ env.DEPENDENCES }}
@@ -76,7 +76,7 @@ jobs:
       matrix:
         # YAML parse `3.10` to `3.1`, so we have to add quotes for `'3.10'`, see also:
         # https://github.com/actions/setup-python/issues/160#issuecomment-724485470
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         # FIXME: temp change os to ubuntu-20.04 to fix python can not found error https://github.com/actions/setup-python/issues/162#issuecomment-1325307787
         os: [ubuntu-20.04, macOS-latest, windows-latest]
         # Skip because dependence [py4j](https://pypi.org/project/py4j/) not work on those environments
@@ -122,10 +122,10 @@ jobs:
         env-list: [doc-build, doc-build-multi]
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.7
+      - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.11
       - name: Install Dependences
         run: |
           python -m pip install --upgrade ${{ env.DEPENDENCES }}
@@ -140,10 +140,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.7
+      - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.11
       - name: Install Dependences
         run: |
           python -m pip install --upgrade ${{ env.DEPENDENCES }}
@@ -195,10 +195,10 @@ jobs:
           -Dcheckstyle.skip=true \
           -Pdocker,release -Ddocker.tag=ci \
           -pl dolphinscheduler-standalone-server -am
-      - name: Set up Python 3.7
+      - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.11
       - name: Install Dependences
         run: |
           python -m pip install --upgrade ${{ env.DEPENDENCES }}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -56,7 +56,7 @@ git commit -am "Release v${VERSION}"
 
 # Add Tag
 git tag -a "${VERSION}" -m "Release v${VERSION}"
-git push "${REMOTE}" --tags
+git push "${REMOTE}" tags/"${VERSION}"
 
 # Build and sign according to the Apache requirements
 python setup.py clean && python setup.py asdist

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -26,6 +26,7 @@ It started after version 2.0.5 released
 
 * Remove attribute tenant from pydolphinscheduler.core.workflow.workflow ([#54](https://github.com/apache/dolphinscheduler-sdk-python/pull/54))
   and please change tenant name in ``config.yaml`` in ``PYDS_HOME``
+* Drop support of python3.6 and python3.7 ([#126](https://github.com/apache/dolphinscheduler-sdk-python/pull/126))
 
 ## 4.0.0
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,9 +42,6 @@ classifiers =
     Operating System :: POSIX
     Operating System :: Microsoft :: Windows
     Programming Language :: Python
-    Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -61,7 +58,7 @@ project_urls =
     Twitter = https://twitter.com/dolphinschedule
 
 [options]
-python_requires = >=3.6
+python_requires = >=3.8
 include_package_data = True
 zip_safe = true
 platforms = any
@@ -172,7 +169,7 @@ envlist =
     code-test
     integrate-test
     local-integrate-test
-    py{36,37,38,39,310,311,312}
+    py{38,39,310,311,312}
 
 [testenv]
 allowlist_externals =


### PR DESCRIPTION
Because both of them are EOL, which you
can see in https://devguide.python.org/versions/

<!--Thanks for you contribute to Apache DolphinScheduler Python API, You can see more detail about contributing in https://github.com/apache/dolphinscheduler-sdk-python/DEVELOP.md .-->

## Brief Summary of The Change

<!--Please include `fixes: #XXXX(ISSUE_NUMBER)` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `related: #XXXX(ISSUE_NUMBER)`.-->

## Pull Request checklist

I confirm that the following checklist has been completed.

- [ ] Add/Change **test cases** for the changes.
- [ ] Add/Change the related **documentation**, should also change `docs/source/config.rst` when you change file `default_config.yaml`.
- [x] (Optional) Add your change to `UPDATING.md` when it is an incompatible change.
