### PR TITLE
ci: update setup-python unsupported version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,10 +87,12 @@ jobs:
             python-version: 3.11
           - os: windows-latest
             python-version: 3.12
-          # Python 3.9 is on macos-13 but not macos-latest (macos-14-arm64)
+          # Python 3.8 and 3.9 is on macos-13 but not macos-latest (macos-14-arm64)
           # https://github.com/actions/setup-python/issues/696#issuecomment-1637587760
           - os: macos-latest
             python-version: 3.9
+          - os: macos-latest
+            python-version: 3.8
         include:
           - os: macos-13
             python-version: 3.9

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,14 +79,23 @@ jobs:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         # FIXME: temp change os to ubuntu-20.04 to fix python can not found error https://github.com/actions/setup-python/issues/162#issuecomment-1325307787
         os: [ubuntu-20.04, macOS-latest, windows-latest]
-        # Skip because dependence [py4j](https://pypi.org/project/py4j/) not work on those environments
         exclude:
+          # Skip because dependence [py4j](https://pypi.org/project/py4j/) not work on those environments
           - os: windows-latest
             python-version: '3.10'
           - os: windows-latest
             python-version: 3.11
           - os: windows-latest
             python-version: 3.12
+          # Python 3.9 is on macos-13 but not macos-latest (macos-14-arm64)
+          # https://github.com/actions/setup-python/issues/696#issuecomment-1637587760
+          - os: macos-latest
+            python-version: 3.9
+        include:
+          - os: macos-13
+            python-version: 3.9
+          - os: macos-13
+            python-version: 3.8
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
python 38 and 39 are not supported on macos-latest anymore, see more detail at
https://github.com/actions/setup-python/issues/696#issuecomment-1637587760

<!--Thanks for you contribute to Apache DolphinScheduler Python API, You can see more detail about contributing in https://github.com/apache/dolphinscheduler-sdk-python/DEVELOP.md .-->

## Brief Summary of The Change

<!--Please include `fixes: #XXXX(ISSUE_NUMBER)` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `related: #XXXX(ISSUE_NUMBER)`.-->

## Pull Request checklist

I confirm that the following checklist has been completed.

- [x] Add/Change **test cases** for the changes.
- [x] Add/Change the related **documentation**, should also change `docs/source/config.rst` when you change file `default_config.yaml`.
- [x] (Optional) Add your change to `UPDATING.md` when it is an incompatible change.
