### PR TITLE
fix: cli config should not require PythonGateway server started

### DIFF
--- a/src/pydolphinscheduler/cli/commands.py
+++ b/src/pydolphinscheduler/cli/commands.py
@@ -26,7 +26,6 @@ from pydolphinscheduler.configuration import (
     init_config_file,
     set_single_config,
 )
-from pydolphinscheduler.core.yaml_workflow import create_workflow
 
 version_option_val = ["major", "minor", "micro"]
 
@@ -103,4 +102,6 @@ def config(getter, setter, init) -> None:
 )
 def yaml(yaml_file) -> None:
     """Create workflow using YAML file."""
+    from pydolphinscheduler.core.yaml_workflow import create_workflow
+
     create_workflow(yaml_file)

--- a/src/pydolphinscheduler/configuration.py
+++ b/src/pydolphinscheduler/configuration.py
@@ -28,6 +28,7 @@ from pydolphinscheduler.utils.yaml_parser import YamlParser
 BUILD_IN_CONFIG_PATH = Path(__file__).resolve().parent.joinpath("default_config.yaml")
 
 logger = logging.getLogger(__name__)
+logging.basicConfig()
 
 
 def config_path() -> Path:
@@ -50,13 +51,14 @@ def get_configs() -> YamlParser:
 
 def init_config_file() -> None:
     """Initialize configuration file by default configs."""
-    if config_path().exists():
+    path: Path = config_path()
+    if path.exists():
         raise PyDSConfException(
             "Initialize configuration false to avoid overwrite configure by accident, file already exists "
             "in %s, if you wan to overwrite the exists configure please remove the exists file manually.",
-            str(config_path()),
+            str(path),
         )
-    file.write(content=str(get_configs()), to_path=str(config_path()))
+    file.write(content=str(get_configs()), to_path=str(path))
 
 
 def get_single_config(key: str) -> Any:
@@ -131,13 +133,12 @@ def token_alert(auth_token: str) -> None:
             "Auth token is None, highly recommend add a token in production, "
             "especially you deploy in public network."
         )
-    with open(BUILD_IN_CONFIG_PATH) as f:
-        config = YamlParser(f.read())
-        if config.get("java_gateway.auth_token") == auth_token:
-            logger.warning(
-                "Auth token is default token, highly recommend add a token in production, "
-                "especially you deploy in public network."
-            )
+    config = get_configs()
+    if config.get("java_gateway.auth_token") == auth_token:
+        logger.warning(
+            "Auth token is default token, highly recommend add a token in production, "
+            "especially you deploy in public network."
+        )
 
 
 def get_int(val: Any) -> int:


### PR DESCRIPTION
<!--Thanks for you contribute to Apache DolphinScheduler Python API, You can see more detail about contributing in https://github.com/apache/dolphinscheduler-sdk-python/DEVELOP.md .-->

## Brief Summary of The Change

<!--Please include `fixes: #XXXX(ISSUE_NUMBER)` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `related: #XXXX(ISSUE_NUMBER)`.-->

cli `configh` subcommand should not require or check wether pythongateway server launched or not, related #153 and https://github.com/apache/dolphinscheduler-sdk-python/issues/152#issuecomment-2314794223

## Pull Request checklist

I confirm that the following checklist has been completed.

- [x] Add/Change **test cases** for the changes.
- [x] Add/Change the related **documentation**, should also change `docs/source/config.rst` when you change file `default_config.yaml`.
- [x] (Optional) Add your change to `UPDATING.md` when it is an incompatible change.
