### PR TITLE
[Fix-8233] Add Google Translate button to Python API docs

### DIFF
--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -1,0 +1,32 @@
+﻿{#
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+#}
+{% extends "!layout.html" %}
+
+{% block extrabody %}
+<div id="google_translate_element" style="position: fixed; bottom: 16px; left: 16px; z-index: 1000;"></div>
+<script type="text/javascript">
+function googleTranslateElementInit() {
+  new google.translate.TranslateElement({
+    pageLanguage: 'en',
+    layout: google.translate.TranslateElement.InlineLayout.SIMPLE
+  }, 'google_translate_element');
+}
+</script>
+<script type="text/javascript" src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
+{% endblock %}


### PR DESCRIPTION
Closes apache/dolphinscheduler#8233

## Description

Add Google Translate widget to the Python API documentation (Sphinx RTD theme).

Currently the Python API docs only have English version. This PR adds a Google Translate dropdown button at the bottom-left corner of the documentation pages, allowing users to translate English docs into their preferred language via machine translation.

## Changes

- Added \docs/source/_templates/layout.html\ that extends the RTD theme's \layout.html\ and injects the Google Translate widget via the \extrabody\ block
- The widget uses \google.translate.TranslateElement\ with \InlineLayout.SIMPLE\

Reference implementation: https://www.commonwl.org/user_guide/